### PR TITLE
fix: production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,11 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      "chrome >= 67",
+      "edge >= 79",
+      "firefox >= 68",
+      "opera >= 54",
+      "safari >= 14"
     ],
     "development": [
       "last 1 chrome version",


### PR DESCRIPTION
This fixes the `Uncaught TypeError: Cannot convert a BigInt value to a number` error